### PR TITLE
List "All" after "100" in the "Submissions shown per page"

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -2364,11 +2364,11 @@ class checkmark {
         $mform->setDefault('filter', $filter);
 
         $mform->addElement('select', 'perpage', get_string('pagesize', 'checkmark'), [
-                0 => get_string('all'),
                 10 => 10,
                 20 => 20,
                 50 => 50,
-                100 => 100
+                100 => 100,
+                0 => get_string('all')
         ]);
         $mform->setDefault('perpage', $perpage);
 


### PR DESCRIPTION
This lists the "Submissions shown per page" options in the right order, from small to large: The "All" entry becomes last.

It fixes https://github.com/academic-moodle-cooperation/moodle-mod_checkmark/issues/52 .

Warning: This is untested.
